### PR TITLE
Compatibility with nette 3.0

### DIFF
--- a/src/DI/AnnotationsExtension.php
+++ b/src/DI/AnnotationsExtension.php
@@ -72,7 +72,7 @@ class AnnotationsExtension extends Nette\DI\CompilerExtension
 	/**
 	 * @return array
 	 */
-	public function getModifiedConfig(array $defaults = NULL)
+	public function getModifiedConfig(array $defaults = [])
 	{
 		$config = $this->validateConfig($defaults);
 

--- a/src/DI/AnnotationsExtension.php
+++ b/src/DI/AnnotationsExtension.php
@@ -83,7 +83,7 @@ class AnnotationsExtension extends Nette\DI\CompilerExtension
 			$config = Nette\DI\Config\Helpers::merge($config, ['ignore' => $globalConfig['doctrine']['ignoredAnnotations']]);
 		}
 
-		return $this->compiler->getContainerBuilder()->expand($config);
+		return Nette\DI\Helpers::expand($config, $this->compiler->getContainerBuilder()->parameters);
 	}
 
 

--- a/src/DI/AnnotationsExtension.php
+++ b/src/DI/AnnotationsExtension.php
@@ -43,7 +43,7 @@ class AnnotationsExtension extends Nette\DI\CompilerExtension
 	public function loadConfiguration()
 	{
 		$builder = $this->getContainerBuilder();
-		$config = $this->getConfig($this->defaults);
+		$config = $this->getModifiedConfig($this->defaults);
 
 		$reflectionReader = $builder->addDefinition($this->prefix('reflectionReader'))
 			->setClass(AnnotationReader::class)
@@ -72,9 +72,9 @@ class AnnotationsExtension extends Nette\DI\CompilerExtension
 	/**
 	 * @return array
 	 */
-	public function getConfig(array $defaults = NULL, $expand = TRUE)
+	public function getModifiedConfig(array $defaults = NULL)
 	{
-		$config = parent::getConfig($defaults, $expand);
+		$config = $this->validateConfig($defaults);
 
 		// ignoredAnnotations
 		$globalConfig = $this->compiler->getConfig();


### PR DESCRIPTION
Compile errors with nette 3.0:
- Declaration of Kdyby\Annotations\DI\AnnotationsExtension::getConfig(?array $defaults = NULL, $expand = true) must be compatible with Nette\DI\CompilerExtension::getConfig(): array
- Call to undefined method Nette\DI\ContainerBuilder::expand()