### PR TITLE
Nette 3.0

### DIFF
--- a/src/DI/AnnotationsExtension.php
+++ b/src/DI/AnnotationsExtension.php
@@ -27,14 +27,6 @@ use Nette\Utils\Validators;
 class AnnotationsExtension extends \Nette\DI\CompilerExtension
 {
 
-	/** @var bool */
-	private $debugMode;
-
-	public function __construct(bool $debugMode = FALSE)
-	{
-		$this->debugMode = $debugMode;
-	}
-
 	public function getConfigSchema(): Schema
 	{
 		return Expect::structure([
@@ -68,8 +60,8 @@ class AnnotationsExtension extends \Nette\DI\CompilerExtension
 			->setClass(Reader::class)
 			->setFactory(CachedReader::class, [
 				$this->prefix('@reflectionReader'),
-				Helpers::processCache($this, $config['cache'], 'annotations', $config['debug'] && $this->debugMode),
-				$config['debug'] && $this->debugMode,
+				Helpers::processCache($this, $config['cache'], 'annotations', $config['debug']),
+				$config['debug'],
 			]);
 
 		// for runtime


### PR DESCRIPTION
Rewrite to ConfigSchema + fix incompatibilities with Kdyby\Doctrine.
A necessary prerequisite for updating Kdyby\Doctrine to support Nette v3.0