### PR TITLE
fix wrong version number reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"nette/di": "^3.0",
 		"nette/utils": "^2.4 || ^3.0",
 		"doctrine/annotations": "~1.6",
-		"kdyby/doctrine-cache": "^2.7.0"
+		"kdyby/doctrine-cache": "^3.0"
 	},
 	"require-dev": {
 		"nette/bootstrap": "^3.0",


### PR DESCRIPTION
Sorry, I did not notice, that you've released version 3.0 in doctrine-cache.
Wrong referenced version caused composer compatibility error in kdyby/doctrine during installation.